### PR TITLE
cpufreq: interactive: Fixup post 4.4.177

### DIFF
--- a/drivers/cpufreq/cpufreq_interactive.c
+++ b/drivers/cpufreq/cpufreq_interactive.c
@@ -1406,7 +1406,7 @@ static ssize_t store_use_migration_notif(
  */
 #define show_gov_pol_sys(file_name)					\
 static ssize_t show_##file_name##_gov_sys				\
-(struct kobject *kobj, struct attribute *attr, char *buf)		\
+(struct kobject *kobj, struct kobj_attribute *attr, char *buf)		\
 {									\
 	return show_##file_name(common_tunables, buf);			\
 }									\
@@ -1419,7 +1419,7 @@ static ssize_t show_##file_name##_gov_pol				\
 
 #define store_gov_pol_sys(file_name)					\
 static ssize_t store_##file_name##_gov_sys				\
-(struct kobject *kobj, struct attribute *attr, const char *buf,		\
+(struct kobject *kobj, struct kobj_attribute *attr, const char *buf,		\
 	size_t count)							\
 {									\
 	return store_##file_name(common_tunables, buf, count);		\


### PR DESCRIPTION
Also fix cpufreq_interactive.c after fde8112c0d5c9 "cpufreq: Use struct
kobj_attribute instead of struct global_attr". Code originates from
5690bb14628d1 "cpufreq: Interactive: Implement per policy instances of
governor". This prevents compiler issues such as:

drivers/cpufreq/cpufreq_interactive.c:1459:21: warning: initialization of
'ssize_t (*)(struct kobject *, struct kobj_attribute *, char *)' {aka
'long int (*)(struct kobject *, struct kobj_attribute *, char *)'} from
incompatible pointer type
'ssize_t (*)(struct kobject *, struct attribute *, char *)' {aka
'long int (*)(struct kobject *, struct attribute *, char *)'}
[-Wincompatible-pointer-types]
error, forbidden warning: cpufreq_interactive.c:1459

Change-Id: Ia29344c8e161c5c05ba43a945276338d3bf7b3f6
Signed-off-by: D. Andrei Măceș <andrei@unlegacy-android.org>