### PR TITLE
smb-lib: clear HVDCP_EN when disabling HVDCP

### DIFF
--- a/drivers/power/supply/qcom/smb-lib.c
+++ b/drivers/power/supply/qcom/smb-lib.c
@@ -1094,13 +1094,8 @@ static int smblib_hvdcp_enable_vote_callback(struct votable *votable,
 	/* vote to enable/disable HW autonomous INOV */
 	vote(chg->hvdcp_hw_inov_dis_votable, client, !hvdcp_enable, 0);
 
-	/*
-	 * Disable the autonomous bit and auth bit for disabling hvdcp.
-	 * This ensures only qc 2.0 detection runs but no vbus
-	 * negotiation happens.
-	 */
 	if (!hvdcp_enable)
-		val = HVDCP_EN_BIT;
+		val = 0;
 
 	rc = smblib_masked_write(chg, USBIN_OPTIONS_1_CFG_REG,
 				 HVDCP_EN_BIT | HVDCP_AUTH_ALG_EN_CFG_BIT,


### PR DESCRIPTION
This is a cherry-pick from the kernel for wahoo to fix the charging issues that prevent Qualcomm QuickCharge chargers from even being able to be used as ordinary DCP chargers.

On mata, the qcom,hvdcp-disable option is specificed for pmi8998. However, the code for "disabling" HVDCP in smb-lib when that option is present doesn't actually prevent the promotion of the power supply type from USB_DCP to USB_HVDCP. And when that happens, the phone seems to repeatedly re-negotiate the connection every five seconds until it eventually settles for charging at 100mA, which is not very useable at all.

Since mata has been marketed as not supporting Qualcomm QuickCharge in any way, it should be acceptable to modify the behavior so that if the qcom,hvdcp-disable option is present, it should just not ever allow the connection to be promoted to HVDCP. Doing so at least allows the mata to use QuickCharge chargers as normal, non-QuickCharge chargers.