### PR TITLE
kernel: Merge in cpufreq stats memory leak fixes

### DIFF
--- a/drivers/cpufreq/cpufreq_stats.c
+++ b/drivers/cpufreq/cpufreq_stats.c
@@ -363,14 +363,24 @@ static int cpufreq_stats_update(struct cpufreq_stats *stats)
 
 void cpufreq_task_stats_init(struct task_struct *p)
 {
-	size_t alloc_size;
-	void *temp;
 	unsigned long flags;
-
 	spin_lock_irqsave(&task_time_in_state_lock, flags);
 	p->time_in_state = NULL;
 	spin_unlock_irqrestore(&task_time_in_state_lock, flags);
 	WRITE_ONCE(p->max_state, 0);
+	spin_lock_irqsave(&task_concurrent_active_time_lock, flags);
+	p->concurrent_active_time = NULL;
+	spin_unlock_irqrestore(&task_concurrent_active_time_lock, flags);
+	spin_lock_irqsave(&task_concurrent_policy_time_lock, flags);
+	p->concurrent_policy_time = NULL;
+	spin_unlock_irqrestore(&task_concurrent_policy_time_lock, flags);
+}
+
+void cpufreq_task_stats_alloc(struct task_struct *p)
+{
+	size_t alloc_size;
+	void *temp;
+	unsigned long flags;
 
 	if (!cpufreq_stats_initialized)
 		return;
@@ -934,6 +944,13 @@ static int process_notifier(struct notifier_block *self,
 	kfree(temp_concurrent_policy_time);
 
 	return NOTIFY_OK;
+}
+
+void cpufreq_task_stats_free(struct task_struct *p)
+{
+	kfree(p->time_in_state);
+	kfree(p->concurrent_active_time);
+	kfree(p->concurrent_policy_time);
 }
 
 static int uid_time_in_state_open(struct inode *inode, struct file *file)

--- a/include/linux/cpufreq.h
+++ b/include/linux/cpufreq.h
@@ -706,6 +706,8 @@ unsigned long cpufreq_scale_max_freq_capacity(int cpu);
 
 void acct_update_power(struct task_struct *p, cputime_t cputime);
 void cpufreq_task_stats_init(struct task_struct *p);
+void cpufreq_task_stats_alloc(struct task_struct *p);
+void cpufreq_task_stats_free(struct task_struct *p);
 void cpufreq_task_stats_remove_uids(uid_t uid_start, uid_t uid_end);
 int  proc_time_in_state_show(struct seq_file *m, struct pid_namespace *ns,
 	struct pid *pid, struct task_struct *p);
@@ -718,6 +720,8 @@ int single_uid_time_in_state_open(struct inode *inode, struct file *file);
 static inline void acct_update_power(struct task_struct *p,
 	cputime_t cputime) {}
 static inline void cpufreq_task_stats_init(struct task_struct *p) {}
+static inline void cpufreq_task_stats_alloc(struct task_struct *p) {}
+static inline void cpufreq_task_stats_free(struct task_struct *p) {}
 static inline void cpufreq_task_stats_exit(struct task_struct *p) {}
 static inline void cpufreq_task_stats_remove_uids(uid_t uid_start,
 	uid_t uid_end) {}

--- a/kernel/fork.c
+++ b/kernel/fork.c
@@ -227,6 +227,9 @@ static void account_kernel_stack(struct thread_info *ti, int account)
 
 void free_task(struct task_struct *tsk)
 {
+#ifdef CONFIG_CPU_FREQ_STAT
+	cpufreq_task_stats_free(tsk);
+#endif
 	account_kernel_stack(tsk->stack, -1);
 	arch_release_thread_info(tsk->stack);
 	free_thread_info(tsk->stack);

--- a/kernel/sched/core.c
+++ b/kernel/sched/core.c
@@ -2345,6 +2345,10 @@ static void __sched_fork(unsigned long clone_flags, struct task_struct *p)
 	memset(&p->se.statistics, 0, sizeof(p->se.statistics));
 #endif
 
+#ifdef CONFIG_CPU_FREQ_STAT
+	cpufreq_task_stats_init(p);
+#endif
+
 	RB_CLEAR_NODE(&p->dl.rb_node);
 	init_dl_task_timer(&p->dl);
 	__dl_clear_params(p);
@@ -2428,11 +2432,12 @@ int sched_fork(unsigned long clone_flags, struct task_struct *p)
 	init_new_task_load(p, false);
 	cpu = get_cpu();
 
+	__sched_fork(clone_flags, p);
+
 #ifdef CONFIG_CPU_FREQ_STAT
-	cpufreq_task_stats_init(p);
+	cpufreq_task_stats_alloc(p);
 #endif
 
-	__sched_fork(clone_flags, p);
 	/*
 	 * We mark the process as running here. This guarantees that
 	 * nobody will actually run it, and a signal or other external

--- a/kernel/sched/core.c
+++ b/kernel/sched/core.c
@@ -2345,10 +2345,6 @@ static void __sched_fork(unsigned long clone_flags, struct task_struct *p)
 	memset(&p->se.statistics, 0, sizeof(p->se.statistics));
 #endif
 
-#ifdef CONFIG_CPU_FREQ_STAT
-	cpufreq_task_stats_init(p);
-#endif
-
 	RB_CLEAR_NODE(&p->dl.rb_node);
 	init_dl_task_timer(&p->dl);
 	__dl_clear_params(p);
@@ -2431,6 +2427,10 @@ int sched_fork(unsigned long clone_flags, struct task_struct *p)
 
 	init_new_task_load(p, false);
 	cpu = get_cpu();
+
+#ifdef CONFIG_CPU_FREQ_STAT
+	cpufreq_task_stats_init(p);
+#endif
 
 	__sched_fork(clone_flags, p);
 	/*


### PR DESCRIPTION
These fixes were made for the wahoo kernel from around June/July 2018, but I noticed that they never got merged into the Essential kernel all this time. The amount of memory that leaks from unfree'd cpufreq stats can get very large depending on how often your Essential Phone exits deep sleep while the screen is off--on a friend's device running the stock rom, after four days, his device was showing that 1.4 GB of ram was used by slab cache, which would leave only around 2.5 GB of ram for userspace processes.